### PR TITLE
Add a filter widget for downloaded files

### DIFF
--- a/dist/DropZone.js
+++ b/dist/DropZone.js
@@ -65,6 +65,7 @@ var DropZone = function (_Component) {
     _this.onDragLeave = _this.onDragLeave.bind(_this);
     _this.onDrop = _this.onDrop.bind(_this);
 
+
     _this.state = {
       overDocument: false,
       over: false
@@ -119,7 +120,7 @@ var DropZone = function (_Component) {
     value: function onClick(event) {
       var _this4 = this;
 
-      (0, _openFile2.default)().then(function (file) {
+      (0, _openFile2.default)(_this4.props).then(function (file) {
         return _this4.triggerOnDrop(file);
       });
     }

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ import DropZone from 'react-drop-zone'
 
 | Name                | Component        | Description                                                                             | Default                        |
 | ---                 | ---              | ---                                                                                     | ---                            |
+| `accept`            | `DropZone`       | Restricts downloads to an extension type.                                               | ---                            |
 | `onDrop` (required) | *both*           | called when a file is dropped or selected. Signature: `(file: HTML5File, text: String)` |                                |
 | `handleClick`       | *both*           | Handle click events on the rendered component                                           | `true`                         |
 | `dontRead`          | *both*           | Prevents reading the file content, if it's causing problems                             | `false`                        |
@@ -53,3 +54,9 @@ import DropZone from 'react-drop-zone'
 
 The component overwrites the `onDrag/DragEnter/.../Drop` props of the render
 function child.
+
+### The accept attribute
+
+If you need more information, see here: ([open developer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Additional_attributes))
+
+The device allows, for example, accept = ".pdf, image/*"

--- a/src/DropZone.js
+++ b/src/DropZone.js
@@ -70,7 +70,7 @@ class DropZone extends Component {
   }
 
   onClick(event) {
-    openFile().then(file => this.triggerOnDrop(file))
+    openFile(this.props).then(file => this.triggerOnDrop(file))
   }
   onDrag(event, document) {
     if (document)


### PR DESCRIPTION
The necessity to enable the filter for audio files (mp3, ogg) led to finding
an inactive function. I suspect there may be reasons to deactivate, but you can
optionally enable acceptance in some projects.